### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 #### Random ideas and someshot useful stuff
 
 ## Features
-- /countnear <radius> <block> (counts how many blocks of x in radius)
+- /countnear <block> <radius> (counts how many blocks of x in radius)
 - /countnear <block> (how many blocks of x in chunk) WIP
 - Keybind system WIP


### PR DESCRIPTION
Change the position of the <block> pram., so when the user proceeds to use /countnear they can input <block> and check the block immediately in the user's chunk without radius causing an unnecessary error due to the order of the param. (ik you prolly forgot abt this but still a suggest lol)